### PR TITLE
Supporting launch detail screen stub.

### DIFF
--- a/app/src/main/java/com/adammcneilly/spacenerd/AppNavHost.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/AppNavHost.kt
@@ -16,6 +16,7 @@ import com.adammcneilly.spacenerd.scaffold.HomeTab
 import com.adammcneilly.spacenerd.scaffold.LocalNavAnimatedVisibilityScope
 import com.adammcneilly.spacenerd.scaffold.app.LocalAppState
 import com.adammcneilly.spacenerd.screens.astronauts.AstronautListScreen
+import com.adammcneilly.spacenerd.screens.launchdetail.LaunchDetailScreen
 import com.adammcneilly.spacenerd.screens.launches.LaunchListScreen
 import com.adammcneilly.spacenerd.screens.news.NewsScreen
 import com.adammcneilly.spacenerd.screens.stations.StationsListScreen
@@ -72,7 +73,11 @@ fun AppNavHost() {
         }
 
         animatedComposable(HomeTab.Launches.route) {
-            LaunchListScreen()
+            LaunchListScreen(
+                navigateToLaunch = { launch ->
+                    navController.navigate("launch/${launch.id}")
+                },
+            )
         }
 
         animatedComposable(HomeTab.Astronauts.route) {
@@ -81,6 +86,10 @@ fun AppNavHost() {
 
         animatedComposable(HomeTab.Stations.route) {
             StationsListScreen()
+        }
+
+        animatedComposable("launch/{launchId}") {
+            LaunchDetailScreen()
         }
     }
 }

--- a/app/src/main/java/com/adammcneilly/spacenerd/core/ui/utils/SharedElement.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/core/ui/utils/SharedElement.kt
@@ -1,0 +1,33 @@
+package com.adammcneilly.spacenerd.core.ui.utils
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.adammcneilly.spacenerd.scaffold.LocalNavAnimatedVisibilityScope
+import com.adammcneilly.spacenerd.scaffold.LocalSharedTransitionScope
+
+/**
+ * Custom wrapper around the Compose foundation sharedElement modifier, that will only apply
+ * if we have the relevant local scopes defined. Otherwise we'll return early with the current modifier.
+ */
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+fun Modifier.sharedElement(
+    key: String,
+): Modifier {
+    val sharedTransitionScope = LocalSharedTransitionScope.current
+    val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
+
+    if (sharedTransitionScope == null || animatedVisibilityScope == null) {
+        return this
+    }
+
+    return with(sharedTransitionScope) {
+        this@sharedElement.sharedElement(
+            sharedContentState = rememberSharedContentState(
+                key = key,
+            ),
+            animatedVisibilityScope = animatedVisibilityScope,
+        )
+    }
+}

--- a/app/src/main/java/com/adammcneilly/spacenerd/data/repositories/LaunchRepository.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/data/repositories/LaunchRepository.kt
@@ -8,4 +8,8 @@ interface LaunchRepository {
     fun getLaunches(
         request: LaunchListRequest,
     ): Flow<List<Launch>>
+
+    fun getLaunch(
+        launchId: String,
+    ): Flow<Launch>
 }

--- a/app/src/main/java/com/adammcneilly/spacenerd/data/thespacedevs/TSDLaunchRepository.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/data/thespacedevs/TSDLaunchRepository.kt
@@ -11,6 +11,22 @@ import javax.inject.Inject
 class TSDLaunchRepository @Inject constructor(
     private val api: TSDRetrofitAPI,
 ) : LaunchRepository {
+    override fun getLaunch(
+        launchId: String,
+    ): Flow<Launch> {
+        return flow {
+            try {
+                val launch = api
+                    .getLaunch(launchId)
+                    .toLaunch()
+
+                emit(launch)
+            } catch (e: Exception) {
+                println("Unable to request launch for id $launchId: $e")
+            }
+        }
+    }
+
     override fun getLaunches(
         request: LaunchListRequest,
     ): Flow<List<Launch>> {

--- a/app/src/main/java/com/adammcneilly/spacenerd/data/thespacedevs/TSDRetrofitAPI.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/data/thespacedevs/TSDRetrofitAPI.kt
@@ -1,7 +1,9 @@
 package com.adammcneilly.spacenerd.data.thespacedevs
 
+import com.adammcneilly.spacenerd.data.thespacedevs.dto.TSDLaunchDTO
 import com.adammcneilly.spacenerd.data.thespacedevs.dto.TSDLaunchListResponseDTO
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface TSDRetrofitAPI {
@@ -11,6 +13,11 @@ interface TSDRetrofitAPI {
         @Query("net__gte") after: String?,
         @Query("net__lte") before: String?,
     ): TSDLaunchListResponseDTO
+
+    @GET("2.3.0/launches/{id}")
+    suspend fun getLaunch(
+        @Path("id") id: String,
+    ): TSDLaunchDTO
 
     @GET("2.3.0/launches/upcoming")
     suspend fun getUpcomingLaunches(): TSDLaunchListResponseDTO

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailContent.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailContent.kt
@@ -1,0 +1,89 @@
+package com.adammcneilly.spacenerd.screens.launchdetail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import com.adammcneilly.spacenerd.core.displaymodels.LaunchDisplayModel
+import com.adammcneilly.spacenerd.core.ui.components.ImageWrapper
+import com.adammcneilly.spacenerd.core.ui.components.Pill
+import com.eygraber.compose.placeholder.PlaceholderDefaults
+import com.eygraber.compose.placeholder.material3.color
+import com.eygraber.compose.placeholder.material3.placeholder
+
+private const val LAUNCH_IMAGE_ASPECT_RATIO = 1.5F
+
+@Composable
+fun LaunchDetailContent(
+    state: LaunchDetailState,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+    ) {
+        item {
+            Box {
+                LaunchImage(
+                    launch = state.launch,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(LAUNCH_IMAGE_ASPECT_RATIO),
+                )
+
+                LaunchStatus(
+                    launch = state.launch,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .statusBarsPadding()
+                        .padding(16.dp)
+                        .placeholder(
+                            visible = state.launch.isPlaceholder,
+                            color = PlaceholderDefaults.color(
+                                contentAlpha = 0.15F,
+                            ),
+                            shape = CircleShape,
+                        ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LaunchImage(
+    launch: LaunchDisplayModel,
+    modifier: Modifier = Modifier,
+) {
+    ImageWrapper(
+        image = launch.image,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+            .placeholder(launch.isPlaceholder),
+    )
+}
+
+@Composable
+private fun LaunchStatus(
+    launch: LaunchDisplayModel,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = LocalTextStyle.current,
+) {
+    Pill(
+        text = launch.status.label,
+        containerColor = launch.status.containerColor,
+        contentColor = launch.status.contentColor,
+        textStyle = textStyle,
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailContent.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.adammcneilly.spacenerd.core.displaymodels.LaunchDisplayModel
 import com.adammcneilly.spacenerd.core.ui.components.ImageWrapper
 import com.adammcneilly.spacenerd.core.ui.components.Pill
+import com.adammcneilly.spacenerd.core.ui.utils.sharedElement
 import com.eygraber.compose.placeholder.PlaceholderDefaults
 import com.eygraber.compose.placeholder.material3.color
 import com.eygraber.compose.placeholder.material3.placeholder
@@ -37,7 +38,10 @@ fun LaunchDetailContent(
                     launch = state.launch,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .aspectRatio(LAUNCH_IMAGE_ASPECT_RATIO),
+                        .aspectRatio(LAUNCH_IMAGE_ASPECT_RATIO)
+                        .sharedElement(
+                            key = "LaunchImage-${state.launch.id}",
+                        ),
                 )
 
                 LaunchStatus(
@@ -52,6 +56,9 @@ fun LaunchDetailContent(
                                 contentAlpha = 0.15F,
                             ),
                             shape = CircleShape,
+                        )
+                        .sharedElement(
+                            key = "LaunchStatus-${state.launch.id}",
                         ),
                 )
             }

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailScreen.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailScreen.kt
@@ -1,0 +1,27 @@
+package com.adammcneilly.spacenerd.screens.launchdetail
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.adammcneilly.spacenerd.scaffold.PersistentScaffold
+import com.adammcneilly.spacenerd.scaffold.rememberScaffoldState
+
+@Composable
+@OptIn(ExperimentalSharedTransitionApi::class)
+fun LaunchDetailScreen(
+    modifier: Modifier = Modifier,
+    viewModel: LaunchDetailViewModel = hiltViewModel(),
+) {
+    val state = viewModel.state.collectAsState()
+
+    rememberScaffoldState().PersistentScaffold(
+        modifier = modifier,
+        content = { scaffoldPadding ->
+            LaunchDetailContent(
+                state = state.value,
+            )
+        },
+    )
+}

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailState.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailState.kt
@@ -1,0 +1,15 @@
+package com.adammcneilly.spacenerd.screens.launchdetail
+
+import com.adammcneilly.spacenerd.core.displaymodels.LaunchDisplayModel
+
+data class LaunchDetailState(
+    val launch: LaunchDisplayModel,
+) {
+    companion object {
+        fun default(): LaunchDetailState {
+            return LaunchDetailState(
+                launch = LaunchDisplayModel.placeholder(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailViewModel.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launchdetail/LaunchDetailViewModel.kt
@@ -1,0 +1,43 @@
+package com.adammcneilly.spacenerd.screens.launchdetail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.adammcneilly.spacenerd.core.displaymodels.LaunchDisplayModel
+import com.adammcneilly.spacenerd.data.repositories.LaunchRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LaunchDetailViewModel @Inject constructor(
+    private val launchRepository: LaunchRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val launchId: String = checkNotNull(savedStateHandle["launchId"])
+
+    private val mutableState = MutableStateFlow(LaunchDetailState.default())
+    val state = mutableState.asStateFlow()
+
+    init {
+        observeLaunch()
+    }
+
+    private fun observeLaunch() {
+        viewModelScope.launch {
+            launchRepository.getLaunch(launchId)
+                .collect { launch ->
+                    val displayModel = LaunchDisplayModel(launch)
+
+                    mutableState.update { currentState ->
+                        currentState.copy(
+                            launch = displayModel,
+                        )
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListContent.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListContent.kt
@@ -1,5 +1,6 @@
 package com.adammcneilly.spacenerd.screens.launches
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
@@ -17,6 +18,7 @@ import com.adammcneilly.spacenerd.scaffold.R as scaffoldR
 fun LaunchListContent(
     state: LaunchListState,
     contentPadding: PaddingValues,
+    onEvent: (LaunchListEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -34,6 +36,10 @@ fun LaunchListContent(
         items(state.launches) { launch ->
             LaunchSummaryCard(
                 launch = launch,
+                modifier = Modifier
+                    .clickable {
+                        onEvent.invoke(LaunchListEvent.LaunchSelected(launch))
+                    },
             )
         }
     }

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListEvent.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListEvent.kt
@@ -1,0 +1,13 @@
+package com.adammcneilly.spacenerd.screens.launches
+
+import com.adammcneilly.spacenerd.core.displaymodels.LaunchDisplayModel
+
+sealed interface LaunchListEvent {
+    data class LaunchSelected(
+        val launch: LaunchDisplayModel,
+    ) : LaunchListEvent
+
+    data class NavigatedToLaunch(
+        val launch: LaunchDisplayModel,
+    ) : LaunchListEvent
+}

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListScreen.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListScreen.kt
@@ -1,28 +1,46 @@
 package com.adammcneilly.spacenerd.screens.launches
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.adammcneilly.spacenerd.core.displaymodels.LaunchDisplayModel
 import com.adammcneilly.spacenerd.scaffold.PersistentScaffold
 import com.adammcneilly.spacenerd.scaffold.navigation.components.PersistentNavigationBar
 import com.adammcneilly.spacenerd.scaffold.navigation.components.PersistentNavigationRail
 import com.adammcneilly.spacenerd.scaffold.rememberScaffoldState
 
 @Composable
-@OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalSharedTransitionApi::class)
 fun LaunchListScreen(
+    navigateToLaunch: (LaunchDisplayModel) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LaunchListViewModel = hiltViewModel(),
 ) {
     val state = viewModel.state.collectAsState()
+    val selectedLaunch = state.value.selectedLaunch
+
+    LaunchedEffect(selectedLaunch) {
+        if (selectedLaunch != null) {
+            navigateToLaunch.invoke(selectedLaunch)
+            viewModel.onEvent(LaunchListEvent.NavigatedToLaunch(selectedLaunch))
+        }
+    }
 
     rememberScaffoldState().PersistentScaffold(
         modifier = modifier,
         navigationBar = {
-            PersistentNavigationBar()
+            PersistentNavigationBar(
+                modifier = Modifier
+                    .animateEnterExit(
+                        enter = slideInVertically(initialOffsetY = { it }),
+                        exit = slideOutVertically(targetOffsetY = { it }),
+                    ),
+            )
         },
         navigationRail = {
             PersistentNavigationRail()
@@ -31,6 +49,7 @@ fun LaunchListScreen(
             LaunchListContent(
                 state = state.value,
                 contentPadding = scaffoldPadding,
+                onEvent = viewModel::onEvent,
             )
         },
     )

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListState.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListState.kt
@@ -4,6 +4,7 @@ import com.adammcneilly.spacenerd.core.displaymodels.LaunchDisplayModel
 
 data class LaunchListState(
     val launches: List<LaunchDisplayModel>,
+    val selectedLaunch: LaunchDisplayModel?,
 ) {
     companion object {
         @Suppress("MagicNumber")
@@ -14,6 +15,7 @@ data class LaunchListState(
 
             return LaunchListState(
                 launches = placeholderLaunches,
+                selectedLaunch = null,
             )
         }
     }

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListViewModel.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchListViewModel.kt
@@ -40,4 +40,35 @@ class LaunchListViewModel @Inject constructor(
                 }
         }
     }
+
+    fun onEvent(
+        event: LaunchListEvent,
+    ) {
+        when (event) {
+            is LaunchListEvent.LaunchSelected -> {
+                processLaunchSelected(event)
+            }
+            is LaunchListEvent.NavigatedToLaunch -> {
+                processNavigatedToLaunch()
+            }
+        }
+    }
+
+    private fun processLaunchSelected(
+        event: LaunchListEvent.LaunchSelected,
+    ) {
+        mutableState.update { currentState ->
+            currentState.copy(
+                selectedLaunch = event.launch,
+            )
+        }
+    }
+
+    private fun processNavigatedToLaunch() {
+        mutableState.update { currentState ->
+            currentState.copy(
+                selectedLaunch = null,
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchSummaryCard.kt
+++ b/app/src/main/java/com/adammcneilly/spacenerd/screens/launches/LaunchSummaryCard.kt
@@ -33,6 +33,7 @@ import com.adammcneilly.spacenerd.core.displaymodels.LaunchStatusDisplayModel
 import com.adammcneilly.spacenerd.core.models.LaunchStatus
 import com.adammcneilly.spacenerd.core.ui.components.ImageWrapper
 import com.adammcneilly.spacenerd.core.ui.components.Pill
+import com.adammcneilly.spacenerd.core.ui.utils.sharedElement
 import com.adammcneilly.spacenerd.scaffold.ui.theme.SpaceTheme
 import com.eygraber.compose.placeholder.PlaceholderDefaults
 import com.eygraber.compose.placeholder.material3.color
@@ -149,7 +150,10 @@ private fun LaunchStatus(
         containerColor = launch.status.containerColor,
         contentColor = launch.status.contentColor,
         textStyle = textStyle,
-        modifier = modifier,
+        modifier = modifier
+            .sharedElement(
+                key = "LaunchStatus-${launch.id}",
+            ),
     )
 }
 
@@ -188,7 +192,10 @@ private fun LaunchImage(
         contentDescription = null,
         contentScale = ContentScale.Crop,
         modifier = modifier
-            .placeholder(launch.isPlaceholder),
+            .placeholder(launch.isPlaceholder)
+            .sharedElement(
+                key = "LaunchImage-${launch.id}",
+            ),
     )
 }
 

--- a/scaffold/src/main/java/com/adammcneilly/spacenerd/scaffold/ScaffoldState.kt
+++ b/scaffold/src/main/java/com/adammcneilly/spacenerd/scaffold/ScaffoldState.kt
@@ -12,12 +12,12 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.window.core.layout.WindowWidthSizeClass
 
 @OptIn(ExperimentalSharedTransitionApi::class)
-val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope> {
-    throw IllegalStateException("Local SharedTransitionScope required")
+val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> {
+    null
 }
 
-val LocalNavAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope> {
-    throw IllegalStateException("Local AnimatedVisibilityScope required")
+val LocalNavAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> {
+    null
 }
 
 /**
@@ -44,8 +44,12 @@ class ScaffoldState internal constructor(
 @Composable
 @OptIn(ExperimentalSharedTransitionApi::class)
 fun rememberScaffoldState(
-    animatedVisibilityScope: AnimatedVisibilityScope = LocalNavAnimatedVisibilityScope.current,
-    sharedTransitionScope: SharedTransitionScope = LocalSharedTransitionScope.current,
+    animatedVisibilityScope: AnimatedVisibilityScope = requireNotNull(LocalNavAnimatedVisibilityScope.current) {
+        "AnimatedVisibilityScope must be provided via LocalNavAnimatedVisibilityScope"
+    },
+    sharedTransitionScope: SharedTransitionScope = requireNotNull(LocalSharedTransitionScope.current) {
+        "SharedTransitionScope must be provided via LocalSharedTransitionScope"
+    },
 ): ScaffoldState {
     val isMediumScreenWidthOrWider = isMediumScreenWidthOrWider()
 


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Detail screen only has image and status for now, but it verifies transition. Unfortunately data is being throttled so now I'm going to look into Room persistence, next. 
